### PR TITLE
SODEV-34087

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,26 @@
-name: Release to v1
+name: Main - Release to v1
 
-on: workflow_dispatch
-
+on:
+    push:
+        branches:
+            - main
 jobs:
     release:
-        name: release
+        name: Release to v1 branch
         runs-on: ubuntu-latest
         steps:
+            - name: Cancel all other runs of this workflow
+              uses: styfle/cancel-workflow-action@0.9.1
+              with:
+                  access_token: ${{ secrets.GITHUB_TOKEN }}
+                  all_but_latest: true
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v2
               with:
                   node-version: 16
                   cache: npm
             - name: Install node modules
-              run: |
-                npm ci
+              run: npm ci
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Bump version & tag
@@ -22,8 +28,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Build
-              run: |
-                npm run build
+              run: npm run build
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Commit dist folder and push to v1 branch

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ const customLabels: CustomLabel[] = [
 ];
 
 const info = (stuff: string) => core.info(stuff);
+const warning = (stuff: string) => core.warning(stuff);
 const error = (stuff: string | Error) => {
 	if (typeof stuff !== 'string' && stuff.stack) {
 		core.error(stuff.stack);
@@ -208,11 +209,15 @@ const handlePullRequest = async () => {
 	if (labelsToRemove.length > 0) {
 		for (const label of labelsToRemove) {
 			info(`Removing label ${label.name}`);
-			await client.rest.issues.removeLabel({
-				...context.repo,
-				issue_number: number,
-				name: label.name
-			});
+			try {
+				await client.rest.issues.removeLabel({
+					...context.repo,
+					issue_number: number,
+					name: label.name
+				});
+			} catch (e) {
+				warning(e)
+			}
 		}
 	} else {
 		info('No labels to remove');
@@ -247,7 +252,7 @@ const run = async () => {
 		if (context.eventName === 'pull_request') {
 			await handlePullRequest();
 		} else {
-			return core.warning('No relevant event found');
+			return warning('No relevant event found');
 		}
 	} catch (e) {
 		error(e);


### PR DESCRIPTION
Problem

When a workflow is rerun after a label is removed, the original pull request event payload is used which still contains the old label. The Sorting Hat tries to remove the label again and throws an error which causes the job and workflow to report as failed

Solution

Log a warning instead of throwing the error